### PR TITLE
toggle auto-rotate and manual rotate

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,9 @@ int main(int argc, char *argv[])
     TrayIcon tray;
     OrientationSensor sensor;
     RotateInput rotateInput;
-    QObject::connect(&sensor, &OrientationSensor::reading, &displayManager, &DisplayManager::setOrientation);
-    QObject::connect(&sensor, &OrientationSensor::reading, &rotateInput, &RotateInput::rotate);
+    QObject::connect(&sensor, &OrientationSensor::reading, &tray, &TrayIcon::orientationUpdated);
+    QObject::connect(&tray, &TrayIcon::emitRotation, &displayManager, &DisplayManager::setOrientation);
+    QObject::connect(&tray, &TrayIcon::emitRotation, &rotateInput, &RotateInput::rotate);
+
     return app.exec();
 }

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -21,25 +21,88 @@
 #include <QTimer>
 #include <QMenu>
 #include <QApplication>
+#include <QDebug>
+#include <QProcessEnvironment>
 
 using namespace std;
 class TrayIcon::Private {
 public:
   QSystemTrayIcon tray;
   unique_ptr<QMenu> menu;
+  Orientation lastOrientation;
+  bool hasLastOrientation;
+  bool autoRotating;
 };
+
+#define APP_NAME tr("Screen Rotator")
+#define APP_ICON QIcon::fromTheme("screenrotator")
 
 TrayIcon::TrayIcon(QObject* parent) : QObject{parent}, d{new Private}
 {
-  d->tray.setIcon(QIcon::fromTheme("screenrotator"));
+  d->tray.setIcon(APP_ICON);
   d->menu.reset(new QMenu());
-  d->tray.setToolTip(tr("Screen Rotator"));
+  d->tray.setToolTip(APP_NAME);
+
+  connect(&d->tray, &QSystemTrayIcon::activated, this, &TrayIcon::activated);
+  connect(&d->tray, &QSystemTrayIcon::messageClicked, this, &TrayIcon::messageClicked);
   
   d->tray.setContextMenu(d->menu.get());
+  d->menu->addAction(tr("Rotate"), this, &TrayIcon::emitRotationIfHas);
+  d->menu->addAction(tr("Toggle auto-rotation"), this, &TrayIcon::toggleAutoRotating);
   d->menu->addAction(tr("Quit"), qApp, &QApplication::quit);
+  d->hasLastOrientation = false;
+
+  QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+  d->autoRotating = !env.contains("DEFAULT_AUTO_ROTATION_OFF");
   QTimer::singleShot(100, &d->tray, &QSystemTrayIcon::show);
 }
 
 TrayIcon::~TrayIcon()
 {
+}
+
+void TrayIcon::setAutoRotating(bool autoRotating)
+{
+  d->autoRotating = autoRotating;
+  if (d->autoRotating) {
+    d->tray.showMessage(APP_NAME, tr("Auto-rotation enabled"), APP_ICON, 3000);
+  } else {
+    d->tray.showMessage(APP_NAME, tr("Auto-rotation disabled"), APP_ICON, 3000);
+  }
+}
+
+void TrayIcon::toggleAutoRotating()
+{
+  this->setAutoRotating(!d->autoRotating);
+}
+
+void TrayIcon::orientationUpdated(Orientation orientation)
+{
+  d->lastOrientation = orientation;
+  d->hasLastOrientation = true;
+  if (d->autoRotating) {
+    this->emitRotationIfHas();
+  } else {
+    d->tray.showMessage(APP_NAME, tr("Orientaion change detected, click tray icon to rotate"), APP_ICON, 3000);
+    qApp->processEvents();
+  }
+}
+
+void TrayIcon::activated(QSystemTrayIcon::ActivationReason reason)
+{
+  this->emitRotationIfHas();
+}
+
+void TrayIcon::messageClicked()
+{
+  this->emitRotationIfHas();
+}
+
+void TrayIcon::emitRotationIfHas()
+{
+  if (d->hasLastOrientation) {
+    emit this->emitRotation(d->lastOrientation);
+  } else {
+    d->tray.showMessage(APP_NAME, tr("No orientaion change detected, try rotate the devise again"), APP_ICON, 5000);
+  }
 }

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -20,6 +20,8 @@
 #define TRAYICON_H
 
 #include <QObject>
+#include <QSystemTrayIcon>
+#include "orientation.h"
 #include <memory>
 class TrayIcon : public QObject
 {
@@ -27,9 +29,18 @@ class TrayIcon : public QObject
 public:
     TrayIcon(QObject* parent = nullptr);
     ~TrayIcon();
+public slots:
+  void setAutoRotating(bool autoRotating);
+  void toggleAutoRotating();
+  void orientationUpdated(Orientation orientation);
+  void activated(QSystemTrayIcon::ActivationReason reason);
+  void messageClicked();
 private:
   class Private;
   std::unique_ptr<Private> d;
+  void emitRotationIfHas();
+signals:
+  void emitRotation(Orientation orientation);
 };
 
 #endif // TRAYICON_H


### PR DESCRIPTION
this project makes auto-rotation a breeze on my Linux setup,
however, sometimes I want to rotate only when I want it to, so I did some modifications and make a fork

by default this fork still does auto-rotation (to make it behave the same as original), but you can turn it off: https://youtu.be/10Fbdn8byM8

when auto-rotation is off (or maybe I should call it manual mode), rotation can be done like this: https://youtu.be/NRrZMKTKHSs

I am not very familiar with C/C++ and Qt projects, let me know if there is anything that should not be done this way